### PR TITLE
Update version to allow installing from github

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ class PyTest(TestCommand):
 
 setup(
     name='Flask-JSONRPC',
-    version='0.3.1',
+    version='0.3.1.dev0',
     url='https://github.com/cenobites/flask-jsonrpc',
     license='New BSD License',
     author='Nycholas de Oliveira e Oliveira',


### PR DESCRIPTION
This allows installation in a `setup.py` (see also https://github.com/cenobites/flask-jsonrpc/pull/57)